### PR TITLE
fix: solve build error due to wrong configuration in dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@socket.tech/ll-core": "0.1.46",
-    "@socket.tech/ll-core-v2": "^0.0.55",
+    "@socket.tech/ll-core": "0.1.49",
+    "@socket.tech/ll-core-v2": "^0.0.68",
     "axios": "^0.27.2",
     "ethers": "^5.6.5",
     "form-data": "^4.0.0",


### PR DESCRIPTION
the version currently used of ll-core and ll-core-v2 contains some error in their package.json configuration. These error have been solved in the latest version of these dependencies.

fixes #11 